### PR TITLE
Override exec command

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,7 @@ default[:sidekiq] = {}
 node[:deploy].each do |application, deploy|
   default[:sidekiq][application.intern] = {}
   default[:sidekiq][application.intern][:restart_command] = "sudo monit restart -g sidekiq_#{application}_group"
-  default[:sidekiq][application.intern][:syslog] = false
+  default[:sidekiq][application.intern][:syslog]          = false
+  default[:sidekiq][application.intern][:exec_command]    = "bundle exec sidekiq"
 end
 

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -68,7 +68,8 @@ node[:deploy].each do |application, deploy|
         :deploy => deploy,
         :application => application,
         :workers => workers,
-        :syslog => node[:sidekiq][application][:syslog]
+        :syslog => node[:sidekiq][application][:syslog],
+        :exec_command => node[:sidekiq][application][:exec_command]
       })
       notifies :reload, resources(:service => "monit"), :immediately
     end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -29,7 +29,7 @@ node[:deploy].each do |application, deploy|
 
   if node[:sidekiq][application]
 
-    workers = node[:sidekiq][application].to_hash.reject {|k,v| k.to_s =~ /restart_command|syslog/ }
+    workers = node[:sidekiq][application].to_hash.reject {|k,v| k.to_s =~ /restart_command|syslog|exec_command/ }
     config_directory = "#{deploy[:deploy_to]}/shared/config"
 
     workers.each do |worker, options|

--- a/templates/default/sidekiq_monitrc.erb
+++ b/templates/default/sidekiq_monitrc.erb
@@ -7,7 +7,7 @@
 
 check process sidekiq_<%= identifier %>
   with pidfile <%= pid_file %>
-  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec sidekiq -C <%= conf_file %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
+  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> <%= @exec_command %> -C <%= conf_file %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
   stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s TERM `cat <%= pid_file %>`'" with timeout 90 seconds
   group sidekiq_<%= @application %>_group
 


### PR DESCRIPTION
This moves the 'bundle exec sidekiq' to an attribute, so it can be varied per app.  In case you're curious, I needed to wrap the command in `xvfb-run`.
